### PR TITLE
Feature/add prerelease flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Parameters:
 
 Options:
 	-version: Displays version
+	-prerelease: Identify the release as a prerelease
 
 Environment variables:
   DEBUG: Allows you to run github-release in debugging mode. DO NOT do this if you are attempting to upload big files.
@@ -42,4 +43,4 @@ Feel free to inspect this project's [Makefile](https://github.com/c4milo/github-
 
 ![](https://cldup.com/6Slplyys6X.png)
 
- 
+

--- a/main.go
+++ b/main.go
@@ -100,13 +100,14 @@ func main() {
 		return
 	}
 
-	if len(os.Args) < 6 {
+	if flag.NArg() != 5 {
+		log.Printf("Error: Invalid number of arguments (got %d, expected 5)\n\n", flag.NArg())
 		log.Fatal(usage)
 	}
 
-	userRepo := strings.Split(os.Args[1], "/")
+	userRepo := strings.Split(flag.Arg(0), "/")
 	if len(userRepo) != 2 {
-		log.Printf("Error: Invalid format used for username and repository: %s\n\n", os.Args[1])
+		log.Printf("Error: Invalid format used for username and repository: %s\n\n", flag.Arg(0))
 		log.Fatal(usage)
 	}
 
@@ -121,12 +122,12 @@ Please refer to https://help.github.com/articles/creating-an-access-token-for-co
 
 	if debug {
 		log.Println("Glob pattern received: ")
-		log.Println(os.Args[5])
+		log.Println(flag.Arg(4))
 	}
 
-	filepaths, err := filepath.Glob(os.Args[5])
+	filepaths, err := filepath.Glob(flag.Arg(4))
 	if err != nil {
-		log.Fatalf("Error: Invalid glob pattern: %s\n", os.Args[5])
+		log.Fatalf("Error: Invalid glob pattern: %s\n", flag.Arg(4))
 	}
 
 	if debug {
@@ -134,9 +135,9 @@ Please refer to https://help.github.com/articles/creating-an-access-token-for-co
 		log.Printf("%v\n", filepaths)
 	}
 
-	tag := os.Args[2]
-	branch := os.Args[3]
-	desc := os.Args[4]
+	tag := flag.Arg(1)
+	branch := flag.Arg(2)
+	desc := flag.Arg(3)
 
 	CreateRelease(tag, branch, desc, filepaths)
 	log.Println("Done")


### PR DESCRIPTION
This PR contains two commits, the first, 8bdab49, is a refactor of the existing code to support an arbitrary number of flags and the second, efc7eef, introduces a new `-prelease` flag.




